### PR TITLE
Terraform version variable updated

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,8 @@ variable "vnf_vpc_image_name" {
   default     = "f5-bigip-15-0-1-0-0-11"
   description = "The name of the F5-BIGIP custom image to be provisioned in your IBM Cloud account."
 }
+
+variable "TF_VERSION" {
+  default = "0.12"
+  description = "terraform engine version to be used in schematics"
+}


### PR DESCRIPTION
This is the variable that tells schematics or content catalog to pick the terraform version specified in the template. All the fix related to f5 are only available in terraform v12 ibm plugin. So default value is mentioned as 0.12
It is only used internally by schematics (& from content catalog). no reference to the actual f5 deployment code
@f5craigsca 