### PR TITLE
removed data source block for image (referred image directly from resource block)

### DIFF
--- a/image.tf
+++ b/image.tf
@@ -29,7 +29,7 @@ data "external" "delete_custom_image" {
   program    = ["bash", "${path.module}/scripts/delete_custom_image.sh"]
 
   query = {
-    custom_image_id = "${data.ibm_is_image.f5_custom_image.id}"
+    custom_image_id = "${ibm_is_image.f5_custom_image.id}"
     region          = "${var.region}"
   }
 }

--- a/image.tf
+++ b/image.tf
@@ -23,11 +23,6 @@ resource "ibm_is_image" "f5_custom_image" {
   }
 }
 
-data "ibm_is_image" "f5_custom_image" {
-  name       = "${var.vnf_vpc_image_name}-${substr(random_uuid.test.result, 0, 8)}"
-  depends_on = ["ibm_is_image.f5_custom_image"]
-}
-
 # Delete custom image from the local user after VSI creation.
 data "external" "delete_custom_image" {
   depends_on = ["ibm_is_instance.f5_ve_instance"]

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ resource "ibm_is_security_group_rule" "f5_tmm_out_icmp" {
 resource "ibm_is_instance" "f5_ve_instance" {
   name    = "${var.instance_name}"
   # image   = data.ibm_is_image.tmos_image.id
-  image   = "${data.ibm_is_image.f5_custom_image.id}"
+  image = "${ibm_is_image.f5_custom_image.id}"
   profile = "${data.ibm_is_instance_profile.instance_profile.id}"
   resource_group   = "${data.ibm_resource_group.rg.id}"
   primary_network_interface {


### PR DESCRIPTION
@f5craigsca 
This is rare intermittent issues, where data source is not picking the latest value based on resource created. We have faced this issue in our sample template sometimes. 

This issue is related to terraform (not specific to ibm provider).

More details here:
https://github.com/hashicorp/terraform/issues/10603